### PR TITLE
Dependecies version bumped

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,9 @@
     },
     "homepage": "https://github.com/ThallyssonKlein/ProductLaunchTemplate#readme",
     "dependencies": {
-        "@react-firebase/firestore": "^0.5.5",
         "date-fns": "^2.21.0",
-        "firebase": "^8.4.1",
-        "next": "^10.1.3",
+        "firebase": "^9.5.0",
+        "next": "^12.0.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
     },


### PR DESCRIPTION
We're now using Next@12, latest version of firebase, and I removed an
unused module: `@react-firebase/firestore`